### PR TITLE
Fix empty structures

### DIFF
--- a/SpecBox.WebApi/Controllers/ProjectController.cs
+++ b/SpecBox.WebApi/Controllers/ProjectController.cs
@@ -124,7 +124,8 @@ public class ProjectController : Controller
             Code = tree.Code,
             Title = tree.Title
         }).ToArrayAsync();
-        if (trees.Length == 0) return NotFound();
+        
+        if (trees.Length == 0) Json(new TreeModel[0]);
 
         return Json(trees);
     }

--- a/SpecBox.WebApi/Controllers/StatController.cs
+++ b/SpecBox.WebApi/Controllers/StatController.cs
@@ -64,16 +64,18 @@ public class StatController : Controller
 
         var assertions = await db.AssertionsStat
             .Where(assertion =>
-                assertion.ProjectId == project.Id &&
+                assertion.Project.Code == project.Code &&
                 assertion.Timestamp >= from &&
                 assertion.Timestamp < to)
+            .OrderBy(s => s.Timestamp)
             .ToArrayAsync();
 
         var autotests = await db.AutotestsStat
             .Where(assertion =>
-                assertion.ProjectId == project.Id &&
+                assertion.Project.Code == project.Code &&
                 assertion.Timestamp >= from &&
                 assertion.Timestamp < to)
+            .OrderBy(s => s.Timestamp)
             .ToArrayAsync();
 
         var model = new StatModel


### PR DESCRIPTION
Исправлен ответ на запрос structures, теперь вместо 404 возвращает пустой массив, если нет описанных деревьев.

Closes: #3 